### PR TITLE
New: Add `schedule-for-midnight-in-jst.yml`

### DIFF
--- a/.github/workflows/schedule-for-midnight-in-jst.yml
+++ b/.github/workflows/schedule-for-midnight-in-jst.yml
@@ -1,0 +1,12 @@
+name: schedule_a_workflow
+on:
+  schedule:
+    - cron: '0 15 * * *' # every 00:00 JST = 15:00 UTC
+      
+jobs:
+  echo-message:
+    name: echo_message
+    runs-on: ubuntu-latest
+    steps:
+      - name: a_happy_new_day
+        run: echo 'A Happy New Day!'


### PR DESCRIPTION
This workflow prints a message at 0:00AM (JST).